### PR TITLE
Add initial database setup script for Articles table

### DIFF
--- a/DB_prueba_tecnica.sql
+++ b/DB_prueba_tecnica.sql
@@ -1,23 +1,22 @@
--- Drop the database if it exists and create a new one
+
 DROP DATABASE IF EXISTS db_prueba_tecnica;
 CREATE DATABASE db_prueba_tecnica;
 
--- Use the newly created database
+
 USE db_prueba_tecnica;
 
--- Create the Articles table
+
 CREATE TABLE Articles (
     id INT AUTO_INCREMENT PRIMARY KEY,
     titular VARCHAR(255) NOT NULL,
     contenido TEXT NOT NULL
 );
 
--- Insert records into the Articles table
+
 INSERT INTO Articles (titular, contenido) VALUES ('Nombre', 'este es el nombre del usuario');
 INSERT INTO Articles (titular, contenido) VALUES ('apellido1', 'Primer apellido del usuario');
 INSERT INTO Articles (titular, contenido) VALUES ('apellido2', 'segundo apellido del usuario');
 INSERT INTO Articles (titular, contenido) VALUES ('edad', 'estos son los años del usuario');
 INSERT INTO Articles (titular, contenido) VALUES ('mes', 'aquí se pone el mes de nacimiento');
 
--- Select all records from the Articles table
 SELECT * FROM Articles;

--- a/DB_prueba_tecnica.sql
+++ b/DB_prueba_tecnica.sql
@@ -1,19 +1,23 @@
-drop database if exists db_prueba_tecnica;
+-- Drop the database if it exists and create a new one
+DROP DATABASE IF EXISTS db_prueba_tecnica;
+CREATE DATABASE db_prueba_tecnica;
 
-create database db_prueba_tecnica;
+-- Use the newly created database
+USE db_prueba_tecnica;
 
-use db_prueba_tecnica;
-
-create table Articles (
-id Int auto_increment primary key,
-ttitular varchar (255) not null,
-contenido text not null
+-- Create the Articles table
+CREATE TABLE Articles (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    titular VARCHAR(255) NOT NULL,
+    contenido TEXT NOT NULL
 );
 
-insert into Articles (titular, contenido) values('Nombre', 'este es el nombre de el usuario');
-insert into Articles (titular, contenido) values ('appellido1', 'Primer aellido del usuario');
-insert into Articlo (titular, contenido) values ('apellido2', 'segundo apellido del usuario');
-insert into Article (titular, contenido) values ('edad', 'este  son los años del usuario');
-insert into Article (titular, contenido) values ('mes',  ' aqui se pone el mes de nacimiento');
+-- Insert records into the Articles table
+INSERT INTO Articles (titular, contenido) VALUES ('Nombre', 'este es el nombre del usuario');
+INSERT INTO Articles (titular, contenido) VALUES ('apellido1', 'Primer apellido del usuario');
+INSERT INTO Articles (titular, contenido) VALUES ('apellido2', 'segundo apellido del usuario');
+INSERT INTO Articles (titular, contenido) VALUES ('edad', 'estos son los años del usuario');
+INSERT INTO Articles (titular, contenido) VALUES ('mes', 'aquí se pone el mes de nacimiento');
 
-select*from Articles;
+-- Select all records from the Articles table
+SELECT * FROM Articles;


### PR DESCRIPTION
The script begins by ensuring that any existing database named db_prueba_tecnica is removed using the DROP DATABASE IF EXISTS db_prueba_tecnica; command. This step is crucial for preventing errors that could arise from trying to create a database that already exists. Following this, the script creates a fresh database named db_prueba_tecnica with the CREATE DATABASE db_prueba_tecnica; command.

Next, the script switches to the newly created database using the USE db_prueba_tecnica; command, preparing the environment for table creation and data insertion. The script then defines a table named Articles with a primary key id that auto-increments, along with two other fields: titular (a string up to 255 characters) and contenido (a text field). This structure is set up with the CREATE TABLE Articles (...) statement.

After establishing the table structure, the script inserts several records into the Articles table. Each INSERT INTO Articles ... VALUES ...; statement adds a new record with specific values for the titular and contenido fields, including information such as the user's name, first and second surname, age, and birth month.